### PR TITLE
cache-register

### DIFF
--- a/environment.d.ts
+++ b/environment.d.ts
@@ -1,4 +1,5 @@
 interface EnvironmentVariables {
+  readonly ALLOW_TTL_MOD: 'true' | 'false'
   readonly NODE_ENV: 'development' | 'production' | 'test'
   readonly ENVIRONMENT: 'development' | 'production' | 'stage' | 'test'
   readonly PORT: string

--- a/src/router/api/v1/lists/buttonState/index.ts
+++ b/src/router/api/v1/lists/buttonState/index.ts
@@ -29,7 +29,7 @@ export function buttonState(lists: Hono<{ Bindings: Environment }>, services: Se
     const efp: IEFPIndexerService = services.efp(env(context))
     const state: FollowStateResponse = await efp.getListFollowingState(token_id, address)
     const packagedResponse = { token_id, address, state }
-    await cacheService.put(cacheTarget, JSON.stringify(packagedResponse))
+    await cacheService.put(cacheTarget, JSON.stringify(packagedResponse), 0)
     return context.json(packagedResponse, 200)
   })
 }

--- a/src/router/api/v1/lists/buttonState/index.ts
+++ b/src/router/api/v1/lists/buttonState/index.ts
@@ -29,7 +29,11 @@ export function buttonState(lists: Hono<{ Bindings: Environment }>, services: Se
     const efp: IEFPIndexerService = services.efp(env(context))
     const state: FollowStateResponse = await efp.getListFollowingState(token_id, address)
     const packagedResponse = { token_id, address, state }
-    await cacheService.put(cacheTarget, JSON.stringify(packagedResponse), 0)
+    if (env(context).ALLOW_TTL_MOD === 'true') {
+      await cacheService.put(cacheTarget, JSON.stringify(packagedResponse), 0)
+    } else {
+      await cacheService.put(cacheTarget, JSON.stringify(packagedResponse))
+    }
     return context.json(packagedResponse, 200)
   })
 }

--- a/src/router/api/v1/lists/followerState/index.ts
+++ b/src/router/api/v1/lists/followerState/index.ts
@@ -29,7 +29,7 @@ export function followerState(lists: Hono<{ Bindings: Environment }>, services: 
     const efp: IEFPIndexerService = services.efp(env(context))
     const state: FollowStateResponse = await efp.getListFollowerState(token_id, address)
     const packagedResponse = { token_id, address, state }
-    await cacheService.put(cacheTarget, JSON.stringify(packagedResponse))
+    await cacheService.put(cacheTarget, JSON.stringify(packagedResponse), 0)
     return context.json(packagedResponse, 200)
   })
 }

--- a/src/router/api/v1/lists/followerState/index.ts
+++ b/src/router/api/v1/lists/followerState/index.ts
@@ -29,7 +29,11 @@ export function followerState(lists: Hono<{ Bindings: Environment }>, services: 
     const efp: IEFPIndexerService = services.efp(env(context))
     const state: FollowStateResponse = await efp.getListFollowerState(token_id, address)
     const packagedResponse = { token_id, address, state }
-    await cacheService.put(cacheTarget, JSON.stringify(packagedResponse), 0)
+    if (env(context).ALLOW_TTL_MOD === 'true') {
+      await cacheService.put(cacheTarget, JSON.stringify(packagedResponse), 0)
+    } else {
+      await cacheService.put(cacheTarget, JSON.stringify(packagedResponse))
+    }
     return context.json(packagedResponse, 200)
   })
 }

--- a/src/router/api/v1/lists/stats/index.ts
+++ b/src/router/api/v1/lists/stats/index.ts
@@ -27,7 +27,7 @@ export function stats(lists: Hono<{ Bindings: Environment }>, services: Services
       following_count: await efp.getUserFollowingCountByList(token_id)
     }
 
-    await cacheService.put(cacheTarget, JSON.stringify(stats))
+    await cacheService.put(cacheTarget, JSON.stringify(stats), 0)
     return context.json(stats, 200)
   })
 }

--- a/src/router/api/v1/lists/stats/index.ts
+++ b/src/router/api/v1/lists/stats/index.ts
@@ -27,7 +27,11 @@ export function stats(lists: Hono<{ Bindings: Environment }>, services: Services
       following_count: await efp.getUserFollowingCountByList(token_id)
     }
 
-    await cacheService.put(cacheTarget, JSON.stringify(stats), 0)
+    if (env(context).ALLOW_TTL_MOD === 'true') {
+      await cacheService.put(cacheTarget, JSON.stringify(stats), 0)
+    } else {
+      await cacheService.put(cacheTarget, JSON.stringify(stats))
+    }
     return context.json(stats, 200)
   })
 }

--- a/src/router/api/v1/users/followerState/index.ts
+++ b/src/router/api/v1/users/followerState/index.ts
@@ -30,7 +30,11 @@ export function followerState(users: Hono<{ Bindings: Environment }>, services: 
     const efp: IEFPIndexerService = services.efp(env(context))
     const state: FollowStateResponse = await efp.getUserFollowerState(addressUser, addressFollower)
     const packagedResponse = { addressUser, addressFollower, state }
-    await cacheService.put(cacheTarget, JSON.stringify(packagedResponse), 0)
+    if (env(context).ALLOW_TTL_MOD === 'true') {
+      await cacheService.put(cacheTarget, JSON.stringify(packagedResponse), 0)
+    } else {
+      await cacheService.put(cacheTarget, JSON.stringify(packagedResponse))
+    }
     return context.json(packagedResponse, 200)
   })
 }

--- a/src/router/api/v1/users/followerState/index.ts
+++ b/src/router/api/v1/users/followerState/index.ts
@@ -30,7 +30,7 @@ export function followerState(users: Hono<{ Bindings: Environment }>, services: 
     const efp: IEFPIndexerService = services.efp(env(context))
     const state: FollowStateResponse = await efp.getUserFollowerState(addressUser, addressFollower)
     const packagedResponse = { addressUser, addressFollower, state }
-    await cacheService.put(cacheTarget, JSON.stringify(packagedResponse))
+    await cacheService.put(cacheTarget, JSON.stringify(packagedResponse), 0)
     return context.json(packagedResponse, 200)
   })
 }

--- a/src/router/api/v1/users/stats/index.ts
+++ b/src/router/api/v1/users/stats/index.ts
@@ -9,7 +9,7 @@ import { isAddress } from '#/utilities'
 export function stats(users: Hono<{ Bindings: Environment }>, services: Services) {
   users.get('/:addressOrENS/stats', async context => {
     const { addressOrENS } = context.req.param()
-    const { cache } = context.req.query()
+    const { live, cache } = context.req.query()
 
     const cacheService = services.cache(env(context))
     const cacheTarget = `users/${addressOrENS}/stats`
@@ -28,17 +28,28 @@ export function stats(users: Hono<{ Bindings: Environment }>, services: Services
       }
     }
     const efp: IEFPIndexerService = services.efp(env(context))
-    const stats = {
-      followers_count: await efp.getUserFollowersCount(address),
-      following_count: await efp.getUserFollowingCount(address)
-    }
+    if (env(context).ALLOW_TTL_MOD === 'true') {
+      const stats = {
+        followers_count: await efp.getUserFollowersCount(address),
+        following_count: await efp.getUserFollowingCount(address)
+      }
 
-    try {
       await cacheService.put(cacheTarget, JSON.stringify(stats), 0)
-    } catch (error) {
-      console.log(error)
+      return context.json(stats, 200)
+    }
+    console.log(env(context).ALLOW_TTL_MOD)
+    const ranksAndCounts = await efp.getUserRanksCounts(address)
+    const stats = {
+      followers_count: ranksAndCounts.followers,
+      following_count: ranksAndCounts.following
     }
 
+    if (live === 'true') {
+      stats.followers_count = await efp.getUserFollowersCount(address)
+      stats.following_count = await efp.getUserFollowingCount(address)
+    }
+
+    await cacheService.put(cacheTarget, JSON.stringify(stats))
     return context.json(stats, 200)
   })
 }

--- a/src/router/api/v1/users/stats/index.ts
+++ b/src/router/api/v1/users/stats/index.ts
@@ -9,11 +9,11 @@ import { isAddress } from '#/utilities'
 export function stats(users: Hono<{ Bindings: Environment }>, services: Services) {
   users.get('/:addressOrENS/stats', async context => {
     const { addressOrENS } = context.req.param()
-    const { live, cache } = context.req.query()
+    const { cache } = context.req.query()
 
     const cacheService = services.cache(env(context))
     const cacheTarget = `users/${addressOrENS}/stats`
-    if (cache !== 'fresh' || live !== 'true') {
+    if (cache !== 'fresh') {
       const cacheHit = await cacheService.get(cacheTarget)
       if (cacheHit) {
         return context.json({ ...cacheHit }, 200)
@@ -28,19 +28,17 @@ export function stats(users: Hono<{ Bindings: Environment }>, services: Services
       }
     }
     const efp: IEFPIndexerService = services.efp(env(context))
-
-    const ranksAndCounts = await efp.getUserRanksCounts(address)
     const stats = {
-      followers_count: ranksAndCounts.followers,
-      following_count: ranksAndCounts.following
+      followers_count: await efp.getUserFollowersCount(address),
+      following_count: await efp.getUserFollowingCount(address)
     }
 
-    if (live === 'true') {
-      stats.followers_count = await efp.getUserFollowersCount(address)
-      stats.following_count = await efp.getUserFollowingCount(address)
+    try {
+      await cacheService.put(cacheTarget, JSON.stringify(stats), 0)
+    } catch (error) {
+      console.log(error)
     }
 
-    await cacheService.put(cacheTarget, JSON.stringify(stats))
     return context.json(stats, 200)
   })
 }

--- a/src/service/cache/service.ts
+++ b/src/service/cache/service.ts
@@ -5,7 +5,7 @@ import type { Environment } from '#/types/index'
 
 export interface ICacheService {
   get(key: string): Promise<{} | null>
-  put(key: string, value: string): Promise<void>
+  put(key: string, value: string, ttl?: number): Promise<void>
 }
 
 export class CacheService implements ICacheService {
@@ -52,16 +52,22 @@ export class CacheService implements ICacheService {
     return this.#env.EFP_DATA_CACHE.get(key, 'json')
   }
 
-  async put(key: string, value: string): Promise<void> {
+  async put(key: string, value: string, ttl = this.#env.CACHE_TTL): Promise<void> {
     if (this.#cacheType === 'redis') {
       if (!this.#client) {
         this.#client = this.createRedisClient()
       }
-      await (this.#client as RedisClientType).set(key, value, {
-        EX: this.#env.CACHE_TTL
-      } as any)
+      if (ttl === 0) {
+        await (this.#client as RedisClientType).set(key, value, {} as any)
+      } else {
+        await (this.#client as RedisClientType).set(key, value, {
+          EX: ttl
+        } as any)
+      }
+    } else if (ttl === 0) {
+      await this.#env.EFP_DATA_CACHE.put(key, value, {})
     } else {
-      await this.#env.EFP_DATA_CACHE.put(key, value, { expirationTtl: this.#env.CACHE_TTL })
+      await this.#env.EFP_DATA_CACHE.put(key, value, { expirationTtl: ttl })
     }
   }
 }


### PR DESCRIPTION
This update modifies certain endpoints to have a non-expiring cache record.  These cache records must be reloaded explicitly by calling with the `cache=fresh` flag and are managed by the cache-register service.

- lists/buttonState
- lists/followerState
- lists/stats
- users/followerState
- users/stats